### PR TITLE
Moved plugins and dependency declarations into parent pom

### DIFF
--- a/java-perf-workshop-tester/pom.xml
+++ b/java-perf-workshop-tester/pom.xml
@@ -16,31 +16,6 @@
         <encoding>UTF-8</encoding>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.gatling</groupId>
-                <artifactId>gatling-app</artifactId>
-                <version>${gatling.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gatling</groupId>
-                <artifactId>gatling-recorder</artifactId>
-                <version>${gatling.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gatling.highcharts</groupId>
-                <artifactId>gatling-charts-highcharts</artifactId>
-                <version>${gatling.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.scala-lang</groupId>
-                <artifactId>scala-library</artifactId>
-                <version>${scala.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.gatling.highcharts</groupId>
@@ -62,20 +37,6 @@
 
     <build>
         <testSourceDirectory>src/test/scala</testSourceDirectory>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>net.alchim31.maven</groupId>
-                    <artifactId>scala-maven-plugin</artifactId>
-                    <version>${scala-maven-plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>io.gatling</groupId>
-                    <artifactId>gatling-maven-plugin</artifactId>
-                    <version>${gatling-maven-plugin.version}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/part_2/README.md
+++ b/part_2/README.md
@@ -127,11 +127,17 @@ loadtest -n 1000 -c 15 "http://localhost:8080/search?q=a"
 
 Alternatively, you can use [gatling](https://gatling.io/) (a performance library with a scala dsl ).
 
-Navigate to the `java-perf-workshop-tester` directory and run `mvn gatling:test`. This should launch the `WorkshopSimulation`. 
+:warning: **This should be run from the `java-perf-workshop-tester` directory**
+
+This should launch the `WorkshopSimulation`.
+
+```bash
+mvn gatling:test
+```
 
 Sample output while running:
 ```bash
-$ mvn gatling:test
+[~/java-perf-workshop/java-perf-workshop-tester]$ mvn gatling:test
 [INFO] Scanning for projects...
 [INFO]
 [INFO] ------------------------------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,11 @@
 
         <!-- tester dependencies -->
         <gatling.version>2.3.0</gatling.version>
+        <scala.version>2.12.3</scala.version>
+
+        <!-- plugin versions -->
         <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
         <gatling-maven-plugin.version>2.2.4</gatling-maven-plugin.version>
-        <scala.version>2.12.3</scala.version>
     </properties>
     <scm>
         <connection>${scm.connection}</connection>
@@ -43,6 +45,15 @@
                 <role>developer</role>
             </roles>
             <timezone>-6</timezone>
+        </developer>
+        <developer>
+          <id>AnEmortalKid</id>
+          <name>Jan Monterrubio</name>
+          <email>janmonterrubio@gmail.com</email>
+          <url>http://github.com/anemortalkid</url>
+          <roles>
+            <role>developer</role>
+          </roles>
         </developer>
     </developers>
     <modules>
@@ -106,14 +117,52 @@
                 <artifactId>junit-dep</artifactId>
                 <version>4.10</version>
             </dependency>
+            <dependency>
+                <groupId>io.gatling</groupId>
+                <artifactId>gatling-app</artifactId>
+                <version>${gatling.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gatling</groupId>
+                <artifactId>gatling-recorder</artifactId>
+                <version>${gatling.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gatling.highcharts</groupId>
+                <artifactId>gatling-charts-highcharts</artifactId>
+                <version>${gatling.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>${scala.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>
+      <pluginManagement>
+        <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>2.3.2</version>
+          </plugin>
+          <plugin>
+              <groupId>io.gatling</groupId>
+              <artifactId>gatling-maven-plugin</artifactId>
+              <version>${gatling-maven-plugin.version}</version>
+          </plugin>
+          <plugin>
+              <groupId>net.alchim31.maven</groupId>
+              <artifactId>scala-maven-plugin</artifactId>
+              <version>${scala-maven-plugin.version}</version>
+          </plugin>
+        </plugins>
+      </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
                 <configuration>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>


### PR DESCRIPTION
While trying to fix #13 , I found that scala would need to be on the classpath in order for `gatling:test` to run from `java-perf-workshop`. Adding a `<dependencies>` to the parent pom felt like the wrong thing to me, since we want the parent to just declare versions and plugins. 

Since I had moved things around, I figured it would be nice to at least consolidate where things were declared for the `java-perf-workshop-tester` module.