### PR TITLE
modify gatling-test command

### DIFF
--- a/part_2/README.md
+++ b/part_2/README.md
@@ -127,9 +127,11 @@ loadtest -n 1000 -c 15 "http://localhost:8080/search?q=a"
 
 Alternatively, you can use [gatling](https://gatling.io/) (a performance library with a scala dsl ).
 
-:warning: **This should be run from the `java-perf-workshop-tester` directory**
-
 This should launch the `WorkshopSimulation`.
+
+```bash
+ mvn -f java-perf-workshop-tester/ gatling:test
+```
 
 ```bash
 mvn gatling:test


### PR DESCRIPTION
modified the gatling-test command to execute from the parent directory since this was a step that was easily missed during class.