### PR TITLE
upgrade dw and wm

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ java -jar java-perf-workshop-server/target/java-perf-workshop-server-1.0-SNAPSHO
 
 #### Mocking Service Dependency
 
-To simulate responses of kcdc.info (as the service may change over time), we will first run a mock 
+To simulate responses of kcdc.info (as the service may change over time), we will first run a mock
 instance of this service using [WireMock](http://wiremock.org/). Go ahead and start another terminal
 session where we will run another service to mock a remote dependency of the workshop service. Navigate
 to the same directory where you cloned this repository, then execute the following commands:
 
 ```bash
-mvn dependency:copy -Dartifact=com.github.tomakehurst:wiremock-standalone:2.5.1 -Dmdep.stripVersion=true -DoutputDirectory=.
+mvn dependency:copy -Dartifact=com.github.tomakehurst:wiremock-standalone:2.24.1 -Dmdep.stripVersion=true -DoutputDirectory=.
 ```
 
 Run the mock service, which will provide the essential end-points to support the service we will be
@@ -96,7 +96,7 @@ logging:
 
 #### Testing
 
-The service will return back results from the KCDC website on sessions that are available which contain 
+The service will return back results from the KCDC website on sessions that are available which contain
 a substring in their title, abstract, or tags. Example:
 
 [http://localhost:8080/search?q=clojure](http://localhost:8080/search?q=clojure)

--- a/java-perf-workshop-server/pom.xml
+++ b/java-perf-workshop-server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>cchesser.javaperf</groupId>
         <artifactId>java-perf-workshop-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-perf-workshop-server</artifactId>
     <name>${project.artifactId}</name>
@@ -67,9 +67,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <scope>test</scope>
+          <groupId>com.github.tomakehurst</groupId>
+          <artifactId>wiremock-jre8</artifactId>
+          <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/java-perf-workshop-tester/pom.xml
+++ b/java-perf-workshop-tester/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java-perf-workshop-parent</artifactId>
         <groupId>cchesser.javaperf</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <groupId>cchesser.javaperf</groupId>
     <artifactId>java-perf-workshop-tester</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <packaging>pom</packaging>
     <groupId>cchesser.javaperf</groupId>
     <artifactId>java-perf-workshop-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <inceptionYear>2015</inceptionYear>
     <properties>
@@ -13,8 +13,8 @@
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
         <!-- Workaround for http://jira.codehaus.org/browse/MRESOURCES-99 -->
         <buildTimestamp>${maven.build.timestamp}</buildTimestamp>
-        <dropwizard.version>0.8.1</dropwizard.version>
-        <metrics.version>3.1.2</metrics.version>
+        <dropwizard.version>1.3.14</dropwizard.version>
+        <metrics.version>4.0.0</metrics.version>
         <jackson.version>2.9.9</jackson.version>
         <jackson.databind.version>2.9.9.1</jackson.databind.version>
         <!-- scm info -->
@@ -64,9 +64,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock</artifactId>
-                <version>2.5.1</version>
+              <groupId>com.github.tomakehurst</groupId>
+              <artifactId>wiremock-jre8</artifactId>
+              <version>2.24.1</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
Upgrades dropwizard and wiremock

Something wasn't jiving between dropwizard and the updated jackson:
```
java -jar java-perf-workshop-server/target/java-perf-workshop-server-1.0-SNAPSHOT.jar server server.yml
Exception in thread "main" java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.deser.SettableBeanProperty.<init>(Lcom/fasterxml/jackson/databind/deser/SettableBeanProperty;Lcom/fasterxml/jackson/databind/JsonDeserializer;)V
```

Tested locally by running the server/tests/jfc etc.

![image](https://user-images.githubusercontent.com/3474369/65000673-1505f100-d8b2-11e9-9c19-3194d624fbeb.png)


Still get the bug that causes memory issues ^ 

I'll probably merge this later tonight jic (for the course 2morrow)