### PR TITLE
Add a shortcode to create a guided section

### DIFF
--- a/docs/content/docs/jmc/_intro_jmc7.md
+++ b/docs/content/docs/jmc/_intro_jmc7.md
@@ -211,8 +211,10 @@ From a Java Flight Recording, there are several categories of information (pages
 * Events:
   __Event Browser__: View detailed log of the events within the JVM. You can use this page to further filter down on events across all the pages in the recording.
 
-We'll touch on a few of these pages in the following sections, starting with the [Method Profiling](/docs/jmc/method_profiling) page.
-
 {{% alert title="Note" color="info" %}}
 Feel free to reference the additional [resources](/docs/jmc/resources) as you navigate through the sections.
 {{% /alert %}}
+
+{{% nextSection %}}
+In the next section, we'll find out more about what our methods are doing.
+{{% /nextSection %}}

--- a/docs/content/docs/jmc/exceptions.md
+++ b/docs/content/docs/jmc/exceptions.md
@@ -32,4 +32,7 @@ You can select an exception from the table to filter the information to that par
   * Are there any other areas in our code where we might have made an incorrect assumption based on an exception's class?
 * Are there any exceptions that might indicate a problem with our dependencies?
 
-In the next section, we'll look at the [Threads](/docs/jmc/threads/) used by our application.
+&nbsp;
+{{% nextSection %}}
+In the next section, we'll look at the Threads used by our application.
+{{% /nextSection %}}

--- a/docs/content/docs/jmc/memory.md
+++ b/docs/content/docs/jmc/memory.md
@@ -33,4 +33,7 @@ Narrow down through some periods of time where our heap rose quickly and then wa
 * Expand the memory usage chart and only chart the Used Heap, do you notice a pattern?
   * What do you think caused the flat line at the end of the chart?
 
-In the next section, we'll look at the [I/O Operations](/docs/jmc/io_operations/) thrown by our application.
+&nbsp;
+{{% nextSection %}}
+In the next section, we'll look at the I/O used by our application.
+{{% /nextSection %}}

--- a/docs/content/docs/jmc/method_profiling.md
+++ b/docs/content/docs/jmc/method_profiling.md
@@ -58,4 +58,6 @@ We can then use this information to correlate what is happening in our code:
 
 *  Is there any method that stands out to you that might be unnecessarily called?
 
-In the next section, we'll look at the [Exceptions](/docs/jmc/exceptions/) thrown by our application.
+{{% nextSection %}}
+In the next section, we'll look at the Exceptions thrown by our application.
+{{% /nextSection %}}

--- a/docs/content/docs/jmc/threads.md
+++ b/docs/content/docs/jmc/threads.md
@@ -50,4 +50,7 @@ There's a couple of threads specifically created by our application, these are t
 * Where are we spending most of our time sleeping? What is causing this?
 * Are there any unnecessary method invocations? Are any threads doing work that isn't visible?
 
-In the next section, we'll look at the [Memory](/docs/jmc/memory) state of the application.
+&nbsp;
+{{% nextSection %}}
+In the next section, we'll look at the Memory state of our application.
+{{% /nextSection %}}

--- a/docs/content/docs/memory/capturing.md
+++ b/docs/content/docs/memory/capturing.md
@@ -48,3 +48,8 @@ the `com.sun.management.HotSpotDiagnostic`. The arguments are:
 * Indicator to dump all live object (true will dump __only live__ objects)
 
 ![hotspot_diag](https://github.com/cchesser/java-perf-workshop/wiki/images/hotspot_diag_mbean.png)
+
+&nbsp;
+{{% nextSection %}}
+In the next section, we'll start analyzing our heap dump with JOverflow.
+{{% /nextSection %}}

--- a/docs/content/docs/memory/challenge.md
+++ b/docs/content/docs/memory/challenge.md
@@ -215,3 +215,8 @@ Since the `WorkshopResource` has a `resultsByContext` field that will get shared
 * The proper solution would be to make the class Thread Safe
 
 {{% /spoiler %}}
+
+&nbsp;
+{{% nextSection %}}
+In the next section, we'll continue learn about Garbage Collection logs.
+{{% /nextSection %}}

--- a/docs/content/docs/memory/heap.md
+++ b/docs/content/docs/memory/heap.md
@@ -24,3 +24,8 @@ which are free. :smiley:
 We will then tie all our knowledge together and attempt to solve a quick challenge:
 
 * [Memory Challenge](/docs/memory/challenge)
+
+&nbsp;
+{{% nextSection %}}
+In the next section, we'll look learn how to acquire a Heap Dump.
+{{% /nextSection %}}

--- a/docs/content/docs/memory/heap.md
+++ b/docs/content/docs/memory/heap.md
@@ -27,5 +27,5 @@ We will then tie all our knowledge together and attempt to solve a quick challen
 
 &nbsp;
 {{% nextSection %}}
-In the next section, we'll look learn how to acquire a Heap Dump.
+In the next section, we'll learn how to acquire a Heap Dump.
 {{% /nextSection %}}

--- a/docs/content/docs/memory/joverflow.md
+++ b/docs/content/docs/memory/joverflow.md
@@ -91,3 +91,8 @@ We can use this same mechanism to also explore values of some of the classes we 
 ![](/joverflow/conference_sessions.png)
 2. Drill down into a couple of the instances
 ![](/joverflow/conference_session_instances.png)
+
+&nbsp;
+{{% nextSection %}}
+In the next section, we'll continue our analysis in Eclipse MAT.
+{{% /nextSection %}}

--- a/docs/content/docs/memory/mat.md
+++ b/docs/content/docs/memory/mat.md
@@ -126,3 +126,8 @@ group by tag_cnt
 order by tag_cnt desc
 ```
 ![](/mat/calcite_tag_distributions.png)
+
+&nbsp;
+{{% nextSection %}}
+In the next section, we'll continue our analysis in VisualVM.
+{{% /nextSection %}}

--- a/docs/content/docs/memory/visualvm.md
+++ b/docs/content/docs/memory/visualvm.md
@@ -284,3 +284,8 @@ toHtml(report)
 ![](/visualvm/tag_distributions_html.png)
 
 {{% /spoiler %}}
+
+&nbsp;
+{{% nextSection %}}
+In the next section, we'll test our knwolege.
+{{% /nextSection %}}

--- a/docs/layouts/shortcodes/nextSection.html
+++ b/docs/layouts/shortcodes/nextSection.html
@@ -1,0 +1,20 @@
+{{/* 
+    Iterates over the set of pages in the current section, locating the current page and creating a link with the contents of the next page.
+  */}}
+  {{ $scratch := newScratch }}
+  {{ range $index, $element := $.Page.CurrentSection.Pages.ByWeight }} 
+    {{ if (eq $.Page.Params.weight .Params.weight) }}
+      {{ $scratch.Set "nextIndex" (add 1 $index)}}
+    {{ end }}
+  {{ end }}
+  {{ with index $.Page.CurrentSection.Pages.ByWeight ($scratch.Get "nextIndex") }}
+  <br/>
+  <div class="card mb-3" style="width: 80%;">
+      <div class="card-header text-white border-info bg-info">
+          <i class="fas fa-arrow-alt-circle-right"></i>&nbsp;&nbsp;Up Next</div>
+      <div class="card-body">
+        <p class="card-text">{{ $.Inner }}</p>
+        <a href="{{ .Permalink }}">{{ .Params.title | title }}</a></i>
+      </div>
+  </div>
+  {{ end}}


### PR DESCRIPTION
Fixes #42 

This shortcode can get dropped at the bottom of the page just to have a pointer to the   'next part' in the section, giving our users an idea of where to click next if the order on the left hand side wasn't obvious.

![image](https://user-images.githubusercontent.com/3474369/109232368-ddc98e00-778d-11eb-99d8-551106d07510.png)
