### PR TITLE
Create images through maven

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: "3.9"  # optional since v1.27.0
+services:
+  wiremock:
+    image: workshop-wiremock:latest
+  server:
+    image: workshop-server:latest
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+    links:
+      - wiremock

--- a/java-perf-workshop-server/pom.xml
+++ b/java-perf-workshop-server/pom.xml
@@ -8,6 +8,10 @@
     </parent>
     <artifactId>java-perf-workshop-server</artifactId>
     <name>${project.artifactId}</name>
+    <properties>
+        <!-- don't build docker by default -->
+        <docker.skip>true</docker.skip>
+    </properties>
     <scm>
         <connection>${scm.connection}</connection>
         <developerConnection>${scm.developerConnection}</developerConnection>
@@ -108,6 +112,66 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.34.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <images>
+                        <image>
+                            <alias>workshop-server</alias>
+                            <name>workshop-server:${project.version}</name>
+                            <build>
+                                <tags>
+                                    <tag>latest</tag>
+                                    <tag>${project.version}</tag>
+                                </tags>
+                                <from>java:8</from>
+                                <assembly>
+                                    <descriptor>server-assembly.xml</descriptor>
+                                </assembly>
+                                <ports>
+                                    <port>8080</port>
+                                    <port>8081</port>
+                                </ports>
+                                <cmd>
+                                    <shell>java -jar \
+                                        /maven/${project.build.finalName}.jar server \
+                                        /maven/server-config.yml</shell>
+                                </cmd>
+                            </build>
+                        </image>
+                        <image>
+                            <alias>workshop-wiremock</alias>
+                            <name>workshop-wiremock:${project.version}</name>
+                            <build>
+                                <tags>
+                                    <tag>latest</tag>
+                                    <tag>${project.version}</tag>
+                                </tags>
+                                <dockerFile>${project.basedir}/src/test/resources/Dockerfile.wiremock</dockerFile>
+                                <contextDir>${project.basedir}/src/test/resources/</contextDir>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>docker</id>
+            <properties>
+                <docker.skip>false</docker.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/java-perf-workshop-server/src/main/docker/server-assembly.xml
+++ b/java-perf-workshop-server/src/main/docker/server-assembly.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>${project.artifactId}</id>
+    <files>
+        <file>
+            <source>target/${project.build.finalName}.jar</source>
+            <outputDirectory>/</outputDirectory>
+        </file>
+        <file>
+            <source>src/main/docker/server-config.yml</source>
+            <outputDirectory>/</outputDirectory>
+        </file>
+    </files>
+</assembly>

--- a/java-perf-workshop-server/src/main/docker/server-config.yml
+++ b/java-perf-workshop-server/src/main/docker/server-config.yml
@@ -1,0 +1,24 @@
+# java-perf-workshop-server
+server:
+  applicationConnectors:
+    - type: http
+      port: 8080
+  adminConnectors:
+    - type: http
+      port: 8081
+
+# Logging settings.
+logging:
+
+  # The default level of all loggers. Can be OFF, ERROR, WARN, INFO, DEBUG, TRACE, or ALL.
+  level: INFO
+
+  # Logger-specific levels.
+  loggers:
+
+    cchesser.javaperf.workshop: DEBUG
+
+  appenders:
+    - type: console
+
+conferenceServiceHost: "wiremock:8080"

--- a/java-perf-workshop-server/src/main/java/cchesser/javaperf/workshop/WorkshopConfiguration.java
+++ b/java-perf-workshop-server/src/main/java/cchesser/javaperf/workshop/WorkshopConfiguration.java
@@ -19,7 +19,7 @@ public class WorkshopConfiguration extends Configuration {
     }
 
     @JsonProperty
-    public void setSonferenceServiceHost(String host) {
+    public void setConferenceServiceHost(String host) {
         this.conferenceServiceHost = host;
     }
 

--- a/java-perf-workshop-server/src/test/java/cchesser/javaperf/workshop/data/BaseTest.java
+++ b/java-perf-workshop-server/src/test/java/cchesser/javaperf/workshop/data/BaseTest.java
@@ -25,12 +25,12 @@ public class BaseTest {
                 .willReturn(aResponse()
                         .withBodyFile("precompilers.json")));
         WorkshopConfiguration conf = new WorkshopConfiguration();
-        conf.setSonferenceServiceHost("localhost:9090");
+        conf.setConferenceServiceHost("localhost:9090");
     }
 
     protected WorkshopConfiguration getConfiguration() {
         WorkshopConfiguration conf = new WorkshopConfiguration();
-        conf.setSonferenceServiceHost("localhost:9090");
+        conf.setConferenceServiceHost("localhost:9090");
         return conf;
     }
 }

--- a/java-perf-workshop-server/src/test/resources/Dockerfile.wiremock
+++ b/java-perf-workshop-server/src/test/resources/Dockerfile.wiremock
@@ -1,0 +1,5 @@
+FROM java:8
+RUN wget https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.27.2/wiremock-standalone-2.27.2.jar -O wiremock-standalone.jar
+COPY __files/ /data/__files/
+COPY mappings/ /data/mappings/
+CMD java -jar wiremock-standalone.jar --root-dir /data/


### PR DESCRIPTION
Precursor to #27 

* Sets up the fabric8io maven plugin to build both a workshop image and a wiremock image, buildable when `docker` profile is set.
* Creates a compose file that depends on those images. 